### PR TITLE
Fix definition of the mean in gx2_params_norm_quad

### DIFF
--- a/gx2_params_norm_quad.m
+++ b/gx2_params_norm_quad.m
@@ -57,5 +57,5 @@ function [w,k,lambda,m,s]=gx2_params_norm_quad(mu,v,quad)
 	[w,~,ic]=uniquetol(nonzeros(d)'); % unique non-zero eigenvalues
 	k=accumarray(ic,1)'; % total dof of each eigenvalue
 	lambda=arrayfun(@(x) sum((b(d==x)).^2),w)./(4*w.^2); % total non-centrality for each eigenvalue
-    m=q0-dot(w,lambda);
+    m=q0-dot(k,lambda);
     s=norm(b(~d));


### PR DESCRIPTION
Replace weight vector `w` by `k`, according to #1 